### PR TITLE
feat:新增可视化界面到患者详情的跳转-

### DIFF
--- a/src/views/plist/PatientDetail.vue
+++ b/src/views/plist/PatientDetail.vue
@@ -109,17 +109,40 @@
     </div>
 
     <div v-else>
-      <el-timeline>
+      <el-timeline class="custom-timeline">
         <el-timeline-item
           v-for="(entry, index) in timelineData"
           :key="index"
           :timestamp="entry.date"
           :type="index === 0 ? 'primary' : 'info'"
           :hollow="index !== 0"
+          :size="index === 0 ? 'large' : 'normal'"
         >
-          <div v-for="item in entry.items" :key="item.label">
-            {{ item.label }}
-          </div>
+          <el-card class="timeline-card" shadow="hover">
+            <div class="timeline-content">
+              <div class="timeline-header">
+                <h4 class="timeline-date">{{ entry.date }}</h4>
+                <span class="item-count">{{ entry.items.length }} 项检查</span>
+              </div>
+              <div class="timeline-items">
+                <div 
+                  v-for="item in entry.items" 
+                  :key="`${item.template_code}-${item.case_code}-${item.time}`"
+                  class="timeline-item"
+                  @click="openTemplateDetailDialog(item.template_code, item.case_code, item.time)"
+                >
+                  <div class="item-info">
+                    <span class="item-name">{{ item.label }}</span>
+                    <span class="item-time">{{ formatTime(item.time) }}</span>
+                  </div>
+                  <div class="item-meta">
+                    <el-tag size="small" type="info">{{ item.case_code }}</el-tag>
+                    <el-icon class="click-icon"><Right /></el-icon>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </el-card>
         </el-timeline-item>
       </el-timeline>
     </div>
@@ -180,7 +203,8 @@
 
 <script setup lang="ts">
 import { ref, reactive, computed, onMounted, PropType } from 'vue';
-import { ElMessage, ElButton, ElDialog, ElTable, ElTableColumn, ElDivider, ElAlert } from 'element-plus';
+import { ElMessage, ElButton, ElDialog, ElTable, ElTableColumn, ElDivider, ElAlert, ElTag, ElIcon, ElCard } from 'element-plus';
+import { Right } from '@element-plus/icons-vue';
 import { caseTemplateSummaryCreate } from '../../api/caseTemplateSummary';
 import { caseTemplateDetailCreate } from '../../api/caseTemplateDetail';
 import { caseUpdate} from '../../api/openApiCase'
@@ -250,7 +274,7 @@ const props = defineProps({
   },
 });
 
-const viewMode = ref('table'); // 'table' or 'timeline'
+const viewMode = ref('timeline'); // 'table' or 'timeline' - 默认显示时间轴视图
 
 const editDialogVisible = ref(false);
 const editForm = reactive({
@@ -529,9 +553,17 @@ const allSections = computed(() => [...leftSections.value, ...rightSections.valu
 
 // Assemble timeline data
 const timelineData = computed(() => {
-  const data: { date: string; items: { label: string; time: string }[] }[] = [];
+  const data: { 
+    date: string; 
+    items: { 
+      label: string; 
+      time: string; 
+      template_code: string; 
+      case_code: string 
+    }[] 
+  }[] = [];
   allSections.value.forEach((section) => {
-    section.items.forEach((item: { label: string; time: string }) => {
+    section.items.forEach((item: { label: string; time: string; template_code: string; case_code: string }) => {
       const found = data.find((t) => t.date === item.time);
       if (found) {
         found.items.push(item);
@@ -560,6 +592,20 @@ const timelineData = computed(() => {
     return { ...entry, date: formattedDate };
   });
 });
+
+// 格式化时间显示
+const formatTime = (dateTimeStr: string) => {
+  try {
+    const date = new Date(dateTimeStr);
+    return date.toLocaleTimeString('zh-CN', { 
+      hour: '2-digit', 
+      minute: '2-digit',
+      hour12: false 
+    });
+  } catch {
+    return dateTimeStr;
+  }
+};
 
 // 组件挂载时获取数据
 onMounted(() => {
@@ -770,5 +816,201 @@ onMounted(() => {
 
 :deep(.el-dialog .el-form-item__label) {
   white-space: nowrap;
+}
+
+/* 时间轴样式优化 */
+.custom-timeline {
+  padding: 10px 0;
+}
+
+.custom-timeline :deep(.el-timeline-item__wrapper) {
+  padding-left: 25px;
+}
+
+.custom-timeline :deep(.el-timeline-item__tail) {
+  border-left: 2px solid #e4e7ed;
+}
+
+.custom-timeline :deep(.el-timeline-item__node) {
+  width: 12px;
+  height: 12px;
+  left: -6px;
+}
+
+.custom-timeline :deep(.el-timeline-item__node--large) {
+  width: 14px;
+  height: 14px;
+  left: -7px;
+}
+
+.timeline-card {
+  margin-bottom: 12px;
+  border-radius: 8px;
+  border: 1px solid #e4e7ed;
+  transition: all 0.3s ease;
+  background: linear-gradient(135deg, #fafbfc 0%, #f5f7fa 100%);
+}
+
+.timeline-card:hover {
+  border-color: #409eff;
+  box-shadow: 0 2px 12px rgba(64, 158, 255, 0.12);
+  transform: translateY(-1px);
+}
+
+.timeline-content {
+  padding: 0;
+}
+
+.timeline-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 16px 8px 16px;
+  border-bottom: 1px solid #f0f2f5;
+  background: linear-gradient(90deg, #409eff 0%, #36c5f0 100%);
+  border-radius: 8px 8px 0 0;
+  color: white;
+  margin: -16px -16px 0 -16px;
+}
+
+.timeline-date {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: white;
+}
+
+.item-count {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.8);
+  background: rgba(255, 255, 255, 0.2);
+  padding: 2px 6px;
+  border-radius: 10px;
+}
+
+.timeline-items {
+  padding: 12px 16px 14px 16px;
+}
+
+.timeline-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  margin-bottom: 6px;
+  background: white;
+  border: 1px solid #f0f2f5;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.timeline-item:last-child {
+  margin-bottom: 0;
+}
+
+.timeline-item::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  background: #409eff;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.timeline-item:hover {
+  border-color: #409eff;
+  background: #f8fcff;
+  transform: translateX(4px);
+}
+
+.timeline-item:hover::before {
+  opacity: 1;
+}
+
+.item-info {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+}
+
+.item-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: #303133;
+  margin-bottom: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.item-time {
+  font-size: 11px;
+  color: #909399;
+}
+
+.item-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.click-icon {
+  color: #c0c4cc;
+  transition: all 0.3s ease;
+  transform: translateX(0);
+}
+
+.timeline-item:hover .click-icon {
+  color: #409eff;
+  transform: translateX(4px);
+}
+
+/* 响应式调整 */
+@media (max-width: 768px) {
+  .custom-timeline {
+    padding: 8px 0;
+  }
+  
+  .custom-timeline :deep(.el-timeline-item__wrapper) {
+    padding-left: 20px;
+  }
+  
+  .timeline-header {
+    padding: 8px 12px 6px 12px;
+    margin: -12px -12px 0 -12px;
+  }
+  
+  .timeline-date {
+    font-size: 13px;
+  }
+  
+  .item-count {
+    font-size: 10px;
+    padding: 2px 4px;
+  }
+  
+  .timeline-items {
+    padding: 10px 12px 12px 12px;
+  }
+  
+  .timeline-item {
+    padding: 6px 10px;
+    margin-bottom: 4px;
+  }
+  
+  .item-name {
+    font-size: 12px;
+  }
+  
+  .item-time {
+    font-size: 10px;
+  }
 }
 </style>

--- a/src/views/visualization/DataAnalysisSelectPatientAndCase.vue
+++ b/src/views/visualization/DataAnalysisSelectPatientAndCase.vue
@@ -12,7 +12,7 @@
           <el-input v-model="search" placeholder="搜索姓名/身份证号" clearable @keyup.enter="fetchPatients" style="width: 240px; margin-right: 12px;" />
           <el-button type="primary" @click="fetchPatients">搜索</el-button>
         </div>
-        <el-table :data="patients" style="width: 100%; margin-top: 16px;" border stripe size="small">
+        <el-table :data="patients" style="width: 100%; margin-top: 16px;" border stripe size="default">
           <el-table-column prop="name" label="姓名" width="120" />
           <el-table-column prop="identity_id" label="身份证号" />
           <el-table-column prop="gender" label="性别" width="80">
@@ -149,13 +149,11 @@ fetchPatients();
 .select-patient-area, .select-case-area {
   padding: 32px 0 0 0;
 }
+
 .search-bar {
   display: flex;
   align-items: center;
   justify-content: flex-end;
 }
 
-.my-large-table {
-  font-size: 24px;
-}
 </style>


### PR DESCRIPTION
    从可视化页面跳转：
    点击"查看病例详情" → 直接显示患者详情页面
    不需要经过档案选择步骤
    智能返回：
    如果是从可视化页面来的：点击返回 → 回到数据分析页面
    如果是正常流程：点击返回 → 回到患者列表
    数据完整性：
    从可视化页面传递的患者数据包含完整的病例信息
    可以正常查看时间轴视图和模板详情

    默认视图切换
    将默认视图从 table 改为 timeline
    用户打开患者详情页面时，直接看到时间轴视图
    2. 时间轴视图交互优化 可点击查看详细：每个检查项目都可以点击，调用 openTemplateDetailDialog 查看详细信息 完整数据传递：确保 template_code、case_code、check_time 正确传递