### PR TITLE
feat: 完善患者详情和数据可视化功能

### DIFF
--- a/src/views/plist/PatientDetail.vue
+++ b/src/views/plist/PatientDetail.vue
@@ -4,6 +4,7 @@
       <el-button icon="Back" @click="goBack"> 返回列表 </el-button>
       <div class="right-toolbar">
         <el-button icon="Edit" type="primary" @click="openEditDialog"> 编辑信息 </el-button>
+        <el-button icon="DataAnalysis" type="success" @click="goToVisualization"> 数据可视化 </el-button>
         <div class="view-switch">
         <!-- 自定义图标：列表视图 -->
         <el-button
@@ -203,6 +204,7 @@
 
 <script setup lang="ts">
 import { ref, reactive, computed, onMounted, PropType } from 'vue';
+import { useRouter } from 'vue-router';
 import { ElMessage, ElButton, ElDialog, ElTable, ElTableColumn, ElDivider, ElAlert, ElTag, ElIcon, ElCard } from 'element-plus';
 import { Right } from '@element-plus/icons-vue';
 import { caseTemplateSummaryCreate } from '../../api/caseTemplateSummary';
@@ -288,6 +290,7 @@ const editForm = reactive({
 });
 
 const emit = defineEmits(['back']);
+const router = useRouter();
 const templateData = ref<CaseTemplateData[]>([]);
 
 // 新增：选中的病例编号列表
@@ -516,6 +519,47 @@ const saveEdit = async () => {
 // Go back to list
 const goBack = () => {
   emit('back');
+  };
+
+// 跳转到数据可视化页面
+const goToVisualization = async () => {
+  if (selectedCaseCodes.value.length === 0) {
+    ElMessage.warning('请至少选择一个病例');
+    return;
+  }
+  
+  if (selectedCaseCodes.value.length > 1) {
+    ElMessage.warning('数据可视化目前只支持单个病例，请选择一个病例');
+    return;
+  }
+  
+  try {
+    // 构造患者和病例数据
+    const selectedCaseCode = selectedCaseCodes.value[0];
+    const patientData = {
+      name: props.patient.identity_name,
+      gender: props.patient.gender === 1 ? '男' : '女',
+      age: props.patient.age.toString(),
+      idCard: props.patient.idCard,
+      caseId: selectedCaseCode
+    };
+    
+    console.log('准备跳转到数据可视化页面，患者数据:', patientData);
+    
+    // 通过localStorage传递数据到可视化页面
+    localStorage.setItem('visualizationPatientData', JSON.stringify(patientData));
+    
+    // 设置来源标记
+    sessionStorage.setItem('fromPatientDetail', 'true');
+    
+    // 跳转到数据可视化页面
+    await router.push('/dashboard/DataAnalysisView');
+    
+    ElMessage.success('正在跳转到数据可视化页面...');
+  } catch (error) {
+    console.error('跳转到数据可视化页面失败:', error);
+    ElMessage.error('跳转失败，请重试');
+  }
 };
 
 // 新增：打开模板详情对话框

--- a/src/views/visualization/DataAnalysisResultDisplay.vue
+++ b/src/views/visualization/DataAnalysisResultDisplay.vue
@@ -14,9 +14,9 @@
           <el-icon><User /></el-icon>
           查看病例详情
         </el-button>
-        <el-button class="back-button" size="small" @click="emit('go-back-to-selection')">
+        <el-button class="back-button" size="small" @click="handleBackNavigation">
           <el-icon><Back /></el-icon>
-          返回选择
+          {{ backButtonText }}
         </el-button>
       </div>
     </div>
@@ -158,7 +158,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, nextTick } from 'vue';
+import { ref, computed, watch, nextTick, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import {
   ElDivider,
@@ -202,6 +202,10 @@ const xAxisOptions = ref([]); // 动态获取的X轴时间选项
 const isLoadingXAxis = ref(false); // X轴数据加载状态
 const expandedTemplates = ref({}); // 控制模板展开状态
 const showResult = computed(() => selectedY.value && selectedX.value.length > 0 && chartValues.value.length > 0);
+
+// 检测是否从患者详情页面进入
+const isFromPatientDetail = ref(false);
+const backButtonText = computed(() => isFromPatientDetail.value ? '返回患者详情' : '返回选择');
 
 // 格式化X轴时间选项显示
 const formattedXAxisOptions = computed(() => {
@@ -436,6 +440,28 @@ watch(() => props.axisData.templateData, () => {
   initExpandedTemplates();
 }, { immediate: true, deep: true });
 
+// 检测进入来源并设置返回行为
+const checkEntrySource = () => {
+  // 检查是否有患者详情页面的标记
+  const fromPatientDetail = sessionStorage.getItem('fromPatientDetail');
+  if (fromPatientDetail) {
+    isFromPatientDetail.value = true;
+    // 使用后清除标记
+    sessionStorage.removeItem('fromPatientDetail');
+  }
+};
+
+// 处理返回导航
+const handleBackNavigation = () => {
+  if (isFromPatientDetail.value) {
+    // 返回患者列表页面
+    router.push('/dashboard/patient-list');
+  } else {
+    // 返回选择页面
+    emit('go-back-to-selection');
+  }
+};
+
 // 跳转到病例详情页面
 const goToPatientDetail = async () => {
   try {
@@ -488,6 +514,11 @@ const goToPatientDetail = async () => {
     ElMessage.error('跳转失败，请重试');
   }
 };
+
+// 组件挂载时检测进入来源
+onMounted(() => {
+  checkEntrySource();
+});
 </script>
 
 <style scoped>

--- a/src/views/visualization/DataAnalysisView.vue
+++ b/src/views/visualization/DataAnalysisView.vue
@@ -39,7 +39,7 @@
 </template>
 
 <script setup>
-import { ref, reactive } from 'vue';
+import { ref, reactive, onMounted } from 'vue';
 import { ElSteps, ElStep, ElMessage, ElDivider, ElIcon } from 'element-plus';
 import { UserFilled, Document, DataAnalysis, Refresh } from '@element-plus/icons-vue';
 import DataAnalysisSelectPatientAndCase from './DataAnalysisSelectPatientAndCase.vue';
@@ -104,6 +104,36 @@ const handleClearSelected = () => {
   currentStep.value = 1;
   resetKey.value++;
 };
+
+// 检测从患者详情页面传递的数据
+const checkPatientDataFromDetails = async () => {
+  try {
+    const storedData = localStorage.getItem('visualizationPatientData');
+    if (storedData) {
+      const patientData = JSON.parse(storedData);
+      console.log('检测到从患者详情页面传递的数据:', patientData);
+      
+      // 清除localStorage中的数据
+      localStorage.removeItem('visualizationPatientData');
+      
+      // 设置患者数据并直接调用选择处理函数
+      await handlePatientCaseSelected({
+        patientName: patientData.name,
+        gender: patientData.gender,
+        age: patientData.age,
+        idCard: patientData.idCard,
+        caseId: patientData.caseId
+      });
+    }
+  } catch (error) {
+    console.error('处理从患者详情页面传递的数据失败:', error);
+  }
+};
+
+// 组件挂载时检查是否有传递的数据
+onMounted(() => {
+  checkPatientDataFromDetails();
+});
 </script>
 
 <style scoped>


### PR DESCRIPTION
主要更新：
- 优化DataAnalysisResultDisplay.vue的Y轴指标选择，按模板分类显示，支持折叠展开
- 在PatientDetail.vue添加"数据可视化"按钮，支持从患者详情直接跳转到可视化页面
- 实现智能的页面间数据传递，使用localStorage和sessionStorage
- 优化可视化页面的返回逻辑，能识别进入来源并提供对应的返回路径
- 添加模板分组的折叠展开UI，提升用户体验和页面整洁度
- 实现患者详情页面与数据可视化页面的双向导航功能

技术改进：
- Y轴指标按模板分类，默认展开第一个模板
- 使用ElCollapseTransition实现平滑的折叠动画
- 智能返回按钮，根据进入来源显示不同文案
- 跨页面数据传递的标准化处理"